### PR TITLE
Enhance UI with card-style history

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,48 +7,50 @@
   <!-- ★ 追加：スマホで横スクロールが起きず 1 倍ズームで表示 -->
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css" />
   <link rel="icon" href="data:,">
 </head>
-<body>
+<body class="min-h-screen bg-gray-100 text-[#111] p-4">
 
   <!-- ===== タブ UI ===== -->
-  <div class="tabs">
+  <div class="flex mb-4">
     <button class="tab-button active" onclick="switchTab('inputTab')">📋 記録する</button>
     <button class="tab-button" onclick="switchTab('graphTab')">📊 グラフで見る</button>
   </div>
 
   <!-- ===== 入力タブ ===== -->
-  <div id="inputTab" class="tab-content">
-    <h1>今月いくら使えるくん</h1>
+  <div id="inputTab" class="tab-content bg-white rounded-xl shadow-lg p-5 space-y-4">
+    <h1 class="text-2xl font-semibold mb-2">今月いくら使えるくん</h1>
 
-    <div class="section">
-      <label>月の予算（円）:</label>
-      <input type="number" id="budgetInput" placeholder="例：30000">
-      <button onclick="setBudget()">設定</button>
+    <div class="space-y-3">
+      <label class="block">月の予算（円）:</label>
+      <input class="w-full p-3 rounded-lg shadow" type="number" id="budgetInput" placeholder="例：30000">
+      <button class="h-12 rounded-lg bg-gradient-to-r from-blue-500 to-blue-600 text-white w-full font-semibold" onclick="setBudget()">設定</button>
     </div>
 
-    <div class="section">
-      <label>支出日:</label>
-      <input type="date" id="dateInput" onchange="updateDisplayByDate()">
-      <label>内容:</label>
-      <input type="text" id="descInput" placeholder="例：ランチ">
-      <label>金額（円）:</label>
-      <input type="number" id="amountInput">
-      <button id="addBtn" onclick="addExpense()">追加</button>
-      <button id="saveBtn" onclick="saveExpenseEdit()" style="display:none;">更新</button>
+    <div class="space-y-3">
+      <label class="block">支出日:</label>
+      <input class="w-full p-3 rounded-lg shadow" type="date" id="dateInput" onchange="updateDisplayByDate()">
+      <label class="block">内容:</label>
+      <input class="w-full p-3 rounded-lg shadow" type="text" id="descInput" placeholder="例：ランチ">
+      <label class="block">金額（円）:</label>
+      <input class="w-full p-3 rounded-lg shadow" type="number" id="amountInput">
+      <button id="addBtn" class="h-12 rounded-lg bg-gradient-to-r from-blue-500 to-blue-600 text-white w-full font-semibold" onclick="addExpense()">追加</button>
+      <button id="saveBtn" class="h-12 rounded-lg bg-gradient-to-r from-blue-500 to-blue-600 text-white w-full font-semibold" onclick="saveExpenseEdit()" style="display:none;">更新</button>
     </div>
 
-    <div class="section">
-      <h2>残り使える金額：<span id="remainingAmount" class="green">0</span> 円</h2>
-      <h3>支出履歴</h3>
-      <ul id="historyList"></ul>
+    <div class="space-y-3">
+      <h2 class="font-semibold">残り使える金額：<span id="remainingAmount" class="green">0</span> 円</h2>
+      <h3 class="font-medium">支出履歴</h3>
+      <ul id="historyList" class="max-h-[300px] overflow-y-auto"></ul>
     </div>
   </div>
 
   <!-- ===== グラフタブ ===== -->
-  <div id="graphTab" class="tab-content" style="display:none;">
-    <h2>月別支出グラフ</h2>
+  <div id="graphTab" class="tab-content bg-white rounded-xl shadow-lg p-5 space-y-4" style="display:none;">
+    <h2 class="text-xl font-semibold">月別支出グラフ</h2>
     <canvas id="monthlyChart" width="400" height="300"></canvas>
   </div>
 

--- a/script.js
+++ b/script.js
@@ -131,10 +131,17 @@ async function updateDisplay(){
     const shortDate = e.date.slice(2).replace(/-/g,"/");  // 2025-05-11 -> 25/05/11
 
     const li = document.createElement("li");
+    li.className = "relative bg-white shadow-md rounded-lg p-4 mb-4";
     li.innerHTML =
-      `<span class="exp-text"><strong>${shortDate}</strong> - ${e.desc}：${e.amount} 円</span>
-       <button class="edit-btn" onclick="startEditExpense('${d.id}')">✏</button>
-       <button class="del-btn" onclick="deleteExpense('${d.id}')">🗑</button>`;
+      `<div>
+         <div class="text-sm text-gray-500">${shortDate}</div>
+         <div class="font-medium mt-1">${e.desc}</div>
+         <div class="mt-1">${e.amount} 円</div>
+       </div>
+       <div class="absolute bottom-3 right-3 flex space-x-3">
+         <button class="edit-btn" onclick="startEditExpense('${d.id}')">✏</button>
+         <button class="del-btn" onclick="deleteExpense('${d.id}')">🗑</button>
+       </div>`;
     historyList.appendChild(li);
   });
 

--- a/style.css
+++ b/style.css
@@ -1,54 +1,21 @@
 /* ===== 共通 ===== */
-body{font-family:'Segoe UI','Hiragino Sans','Noto Sans JP',sans-serif;background:linear-gradient(135deg,#f0f0f3,#d9dee8);padding:16px;}
-input,button{width:100%;margin:6px 0 12px;padding:10px;font-size:1rem;box-sizing:border-box;}
-button{background:linear-gradient(135deg,#4a90e2,#007aff);color:#fff;border:none;border-radius:6px;cursor:pointer;box-shadow:0 2px 4px rgba(0,0,0,.2);}
+body{font-family:'Inter',sans-serif;background:#f5f5f5;color:#111;padding:1rem;}
 ul{list-style:none;padding:0;margin:0;}
 .green{color:#0baf4b;font-weight:bold;}
 .red  {color:#f44336;font-weight:bold;}
 
+/* ===== タブ ===== */
+.tab-button{background:#fff;border:none;flex:1 1 50%;padding:0.5rem 0;border-radius:0.5rem 0.5rem 0 0;cursor:pointer;box-shadow:0 1px 2px rgba(0,0,0,.05);font-weight:600;}
+.tab-button.active{background-image:linear-gradient(to right,#3b82f6,#2563eb);color:#fff;box-shadow:0 2px 4px rgba(0,0,0,.1);}
 /* タブ & カード */
-.tab-button{background:#f8f8f8;color:#333;border:none;padding:12px;font-size:1rem;transition:background .3s;
-            margin-right:4px;border-radius:8px 8px 0 0;cursor:pointer;flex:1 1 50%;}
-.tab-button.active{background:linear-gradient(135deg,#4a90e2,#007aff);color:#fff;}
-.tab-content{max-width:600px;margin:auto;background:#fff;padding:20px;
-             border-radius:12px;box-shadow:0 8px 20px rgba(0,0,0,.15);box-sizing:border-box;}
+.tab-content{max-width:600px;margin:auto;}
 
-/* ===== 支出履歴行 ===== */
-li{
-  display:flex;                 /* 左:テキスト  右:アイコン */
-  gap:12px;
-  align-items:center;
-  background:#fafafa;
-  padding:12px 16px;
-  border-radius:8px;
-  margin-bottom:10px;
-  line-height:1.4; box-shadow:0 2px 4px rgba(0,0,0,.1);
-}
-
-.exp-text{
-  flex:1 1 0;                  /* 余った幅いっぱい */
-  min-width:0;                 /* flex の縮み許可 */
-  white-space:nowrap;          /* 1 行固定（改行させない） */
-}
-
-.del-btn{
-  flex:0 0 24px;               /* 幅固定で右端 */
-  background:transparent;border:none;cursor:pointer;
-  color:#f44336;font-size:22px;line-height:1;
-}
-.edit-btn{
-  transform:scaleX(-1);
-  flex:0 0 24px;
-  background:transparent;border:none;cursor:pointer;
-  color:#2196f3;font-size:22px;line-height:1;
-}
+.del-btn,.edit-btn{background:transparent;border:none;font-size:1.25rem;line-height:1;}
+.del-btn{color:#f44336;}
+.edit-btn{color:#2196f3;transform:scaleX(-1);}
 
 /* ===== スマホ ===== */
 @media(max-width:480px){
   body{padding:10px;}
   .tab-content{max-width:100%;padding:16px;}
-  input,button{font-size:1.05rem;padding:12px;}
-  .tab-button{font-size:.95rem;margin-right:2px;}
-  .del-btn{font-size:20px;flex-basis:20px;}
-  .edit-btn{font-size:20px;flex-basis:20px;}
 }


### PR DESCRIPTION
## Summary
- tune button and tab styles for cleaner Inter-themed UI
- render expense history as cards with bottom-right edit/delete icons
- soften layout spacing and background color

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842d55fd324832690f938df335e333c